### PR TITLE
add confirm password logic

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -920,7 +920,11 @@ export default function CommunityPage() {
                             <span>
                               {typeof event.date === "string"
                                 ? event.date
-                                : new Date(event.date).toLocaleDateString()}
+                                : (event.date instanceof Date
+                                    ? event.date.toLocaleDateString()
+                                    : typeof event.date.toDate === "function"
+                                      ? event.date.toDate().toLocaleDateString()
+                                      : "")}
                               , {event.time}
                             </span>
                           </div>

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -838,7 +838,12 @@ s
 
     // Initialize content object if it doesn't exist
     if (!updatedModules[moduleIndex].lessons[lessonIndex].content) {
-      updatedModules[moduleIndex].lessons[lessonIndex].content = {};
+      updatedModules[moduleIndex].lessons[lessonIndex].content = {
+        videoUrl: "",
+        description: "",
+        transcript: "",
+        attachments: [],
+      };
     }
 
     // Update attachments
@@ -2079,9 +2084,7 @@ s
                                                                   <div className="min-h-[250px] sm:min-h-[300px] border border-blue-100 dark:border-blue-900 rounded-md overflow-hidden">
                                                                     <TipTapEditor
                                                                       value={
-                                                                        lesson
-                                                                          .content
-                                                                          ?.textContent ||
+                                                                        (lesson.content as { textContent?: string })?.textContent ||
                                                                         ""
                                                                       }
                                                                       onChange={(

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -20,6 +20,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { db } from "@/lib/firebase";
 import { doc, getDoc } from "firebase/firestore";
 import { UserCredential } from "firebase/auth";
+import { Eye, EyeOff } from "lucide-react";
 
 export default function LoginPage() {
   const { user } = useAuth();
@@ -27,6 +28,7 @@ export default function LoginPage() {
   const { signIn, signInWithGoogle, signInWithGithub } = useAuth();
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   // If user is already logged in, redirect to dashboard
   if (user) {
     router.push("/dashboard");
@@ -140,8 +142,28 @@ export default function LoginPage() {
                     Forgot password?
                   </Link>
                 </div>
-                <Input id="password" name="password" type="password" required />
+                <div className="relative">
+                  <Input
+                    id="password"
+                    name="password"
+                    type={showPassword ? "text" : "password"}
+                    required
+                  />
+                  <button
+                    type="button"
+                    className="absolute -translate-y-1/2 right-2 top-1/2 text-muted-foreground"
+                    tabIndex={-1}
+                    onClick={() => setShowPassword((v) => !v)}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-5 h-5" />
+                    ) : (
+                      <Eye className="w-5 h-5" />
+                    )}
+                  </button>
+                </div>
               </div>
+
               <Button className="w-full" type="submit" disabled={loading}>
                 {loading ? "Logging in..." : "Login"}
               </Button>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Footer } from "@/components/footer";
 import { toast } from "@/components/ui/use-toast";
-
+import { Eye, EyeOff } from "lucide-react";
 interface FormData {
   firstName: string;
   lastName: string;
@@ -54,15 +54,29 @@ export default function SignupPage() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value, type, checked } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [id === "first-name"
-        ? "firstName"
-        : id === "last-name"
-        ? "lastName"
-        : id]: type === "checkbox" ? checked : value,
-    }));
+    setFormData((prev) => {
+      const updated = {
+        ...prev,
+        [id === "first-name"
+          ? "firstName"
+          : id === "last-name"
+          ? "lastName"
+          : id]: type === "checkbox" ? checked : value,
+      };
+
+      if (id === "password" || id === "confirmPassword") {
+        setPasswordsMatch(
+          id === "password"
+            ? value === prev.confirmPassword
+            : prev.password === value
+        );
+      }
+      return updated;
+    });
   };
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passwordsMatch, setPasswordsMatch] = useState(true);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -182,38 +196,58 @@ export default function SignupPage() {
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="m@example.com"
-                  value={formData.email}
-                  onChange={handleChange}
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  value={formData.password}
-                  onChange={handleChange}
-                  required
-                />
+                <div className="relative">
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    value={formData.password}
+                    onChange={handleChange}
+                    required
+                  />
+                  <button
+                    type="button"
+                    className="absolute -translate-y-1/2 right-2 top-1/2 text-muted-foreground"
+                    tabIndex={-1}
+                    onClick={() => setShowPassword((v) => !v)}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-5 h-5" />
+                    ) : (
+                      <Eye className="w-5 h-5" />
+                    )}
+                  </button>
+                </div>
+
                 <p className="text-xs text-muted-foreground">
                   Password must be at least 8 characters long
                 </p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="confirm-password">Confirm Password</Label>
-                <Input
-                  id="confirmPassword"
-                  type="password"
-                  value={formData.confirmPassword}
-                  onChange={handleChange}
-                  required
-                />
+                <div className="relative">
+                  <Input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                    required
+                  />
+                  <button
+                    type="button"
+                    className="absolute -translate-y-1/2 right-2 top-1/2 text-muted-foreground"
+                    tabIndex={-1}
+                    onClick={() => setShowConfirmPassword((v) => !v)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="w-5 h-5" />
+                    ) : (
+                      <Eye className="w-5 h-5" />
+                    )}
+                  </button>
+                </div>
+                {!passwordsMatch && (
+                  <p className="text-xs text-red-600">Passwords do not match</p>
+                )}
               </div>
               <div className="flex items-center space-x-2">
                 <input


### PR DESCRIPTION
- Added an eye icon toggle to show/hide password fields on both login and signup pages.
- Signup form now displays a real-time error message if passwords do not match.
- Improves user experience and reduces password entry errors.
