### PR TITLE
feat: Implement 2FA Email Verification for signin

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -95,7 +95,7 @@ export default function LoginPage() {
     try {
       const signInFn =
         provider === "google" ? signInWithGoogle : signInWithGithub;
-      const userCredential: UserCredential = await signInFn();
+      const userCredential = (await signInFn?.()) as UserCredential | undefined;
       if (userCredential && userCredential.user) {
         await fetch("/api/token/verify-2fa", {
           method: "POST",

--- a/context/AuthProvider.tsx
+++ b/context/AuthProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState } from "react";
-import { User, getIdToken, onAuthStateChanged } from "firebase/auth";
+import { User, UserCredential, getIdToken, onAuthStateChanged } from "firebase/auth";
 import {
   collection,
   doc,


### PR DESCRIPTION
After successful login (email/password), generate a random 2FA code, store it in Firestore, and send it to the user's email.
Redirect users to /verify-2fa?email=... after authentication, requiring them to enter the code before accessing their account.
Store pending user info in [localStorage](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) until verification is complete.
Improved error handling and UI feedback for the login process.
Ensures users are not considered logged in until they complete 2FA verification.